### PR TITLE
fix: 使用 encodeURI 编码 URL

### DIFF
--- a/src/views/index/components/dialog/SendHaJimiInvitationDialog.vue
+++ b/src/views/index/components/dialog/SendHaJimiInvitationDialog.vue
@@ -24,7 +24,7 @@
                 :icon-size="50"
               />
             </n-tab-pane>
-            <n-tab-pane name="link" tab="通过分享链接">
+            <n-tab-pane name="link" tab="通过分享链接" style="height: 215px">
               <n-button
                 type="primary"
                 ghost
@@ -42,11 +42,8 @@
               <n-input
                 :value="getSharedURL()"
                 type="textarea"
-                :autosize="{
-                  minRows: 5,
-                  maxRows: 9,
-                }"
                 readonly
+                style="height: 175px"
               />
             </n-tab-pane>
           </n-tabs>
@@ -207,7 +204,7 @@ watch(yourIdentityStr, (newVal) => {
 function getSharedURL() {
   const origin = window.location.origin
   const query = `/hajimi/?invite=${myIdentityStr.value}`
-  return origin + query
+  return encodeURI(origin + query)
 }
 
 function startChat() {


### PR DESCRIPTION
1. 使用 encodeURI 编码 URL，避免分享链接在QQ等软件无法识别为超链接（#12）
2. 修复tab切换时高度变化

<img width="400" height="528" alt="image" src="https://github.com/user-attachments/assets/ab21b8ff-e9d9-4ad4-9f50-3eb7da5285cf" />

<img width="466" height="240" alt="image" src="https://github.com/user-attachments/assets/d7dfd0dd-044b-4f59-8479-8154b1e06a48" />

![Screenshot_2025_0811_112050](https://github.com/user-attachments/assets/aaa0c303-7be8-465e-b64d-7db40d0e451f)
