### PR TITLE
fix:修正页脚描述

### DIFF
--- a/frontend-next/src/components/foot-note/FootNote.vue
+++ b/frontend-next/src/components/foot-note/FootNote.vue
@@ -21,8 +21,7 @@
     <!-- 第三行块：版权信息、版本信息 -->
     <div class="block">
       <span>
-        Copyleft 🄯 {{ getYearSince() }} 哈基密文加密器 v{{ version }}
-      </span>
+        Copyright (C) {{ getYearSince() }} 哈基密文加密器 v{{ version }}. Licensed under GPLv3      </span>
       <span class="git-commit">
         <span>(</span>
         <foot-a-link :icon-svg="commitSvg" :href="`https://github.com/wifi504/translate-ha-jimi/commit/${gitSha}`">
@@ -31,7 +30,7 @@
         <span>)</span>
       </span>
       <span>
-        保留自由权利 All Freedom reserved.
+        All Rights Reversed.
       </span>
     </div>
     <!-- 第四行块：备案信息、额外信息 -->

--- a/frontend-next/src/components/foot-note/FootNote.vue
+++ b/frontend-next/src/components/foot-note/FootNote.vue
@@ -21,7 +21,7 @@
     <!-- 第三行块：版权信息、版本信息 -->
     <div class="block">
       <span>
-        Copyright © {{ getYearSince() }} 哈基密文加密器 v{{ version }}
+        Copyleft 🄯 {{ getYearSince() }} 哈基密文加密器 v{{ version }}
       </span>
       <span class="git-commit">
         <span>(</span>
@@ -31,7 +31,7 @@
         <span>)</span>
       </span>
       <span>
-        版权所有 All Rights Reserved.
+        保留自由权利 All Freedom reserved.
       </span>
     </div>
     <!-- 第四行块：备案信息、额外信息 -->


### PR DESCRIPTION
页脚有错误的 Copyright © 2025 哈基密语加密器 All Rights  Reserves. 错误描述，其违反GPL3协议，容易对用户造成混淆

改为 

Copyleft 🄯 2025 哈基密文加密器 v3.0 保留自由权利 All Freedom Reserves.

**Copyleft授权条款不反对著作权的基本体制**

<img width="566" height="162" alt="image" src="https://github.com/user-attachments/assets/1dc7dfbd-5b5e-4f1b-a20d-fef51951eb0a" />
